### PR TITLE
Do not keep mpv open after notification is done playing

### DIFF
--- a/instantnotifytrigger.sh
+++ b/instantnotifytrigger.sh
@@ -35,9 +35,9 @@ if ! grep -iqF "$1" ~/.config/instantos/notifysilent && ! iconf -i mutenotificat
 
     if ! iconf -i nonotify; then
         if [ -e ~/instantos/notifications/customsound ]; then
-            mpv ~/instantos/notifications/customsound
+            mpv --keep-open='no' ~/instantos/notifications/customsound
         else
-            mpv ~/instantos/notifications/notification.ogg
+            mpv --keep-open='no' ~/instantos/notifications/notification.ogg
         fi
     fi
 


### PR DESCRIPTION
I noticed sometimes pipewire/pipewire-pulse crashes after certain amount of mpv instances open.
I think we do not need mpv being kept open after notification is done playing?


Signed-off-by: Dušan <dusan.uveric@mitigate.dev>
